### PR TITLE
fix: 内部线程在关闭时没有清理干净

### DIFF
--- a/src/main/java/com/jarvis/cache/RefreshHandler.java
+++ b/src/main/java/com/jarvis/cache/RefreshHandler.java
@@ -93,6 +93,12 @@ public class RefreshHandler {
 
     public void shutdown() {
         refreshThreadPool.shutdownNow();
+        try {
+            refreshThreadPool.awaitTermination(5, TimeUnit.SECONDS);
+        }
+        catch (InterruptedException e) {
+            e.printStackTrace();
+        }
     }
 
     class RefreshTask implements Runnable {

--- a/src/main/java/com/jarvis/cache/map/CachePointCut.java
+++ b/src/main/java/com/jarvis/cache/map/CachePointCut.java
@@ -70,6 +70,8 @@ public class CachePointCut extends AbstractCacheManager {
     public synchronized void destroy() {
         super.destroy();
         cacheTask.destroy();
+        if (thread != null)
+            thread.interrupt();
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
RefreshHandler的线程池需要用awaitTermination稍微等一下

CachePointCut的内部线程的默认唤醒周期是1分钟, 需要中断一下使其自行退出