### PR TITLE
fix: 数据加载异常时，续租功能失效的问题

### DIFF
--- a/src/main/java/com/jarvis/cache/AutoLoadHandler.java
+++ b/src/main/java/com/jarvis/cache/AutoLoadHandler.java
@@ -376,11 +376,11 @@ public class AutoLoadHandler {
             try {
                 newCacheWrapper = dataLoader.init(pjp, autoLoadTO, cacheKey, cache, cacheHandler).loadData()
                         .getCacheWrapper();
-                isFirst = dataLoader.isFirst();
                 loadDataUseTime = dataLoader.getLoadDataUseTime();
             } catch (Throwable e) {
                 log.error(e.getMessage(), e);
             } finally {
+                isFirst = dataLoader.isFirst();
                 if (config.isDataLoaderPooled()) {
                     DataLoaderFactory factory = DataLoaderFactory.getInstance();
                     factory.returnObject(dataLoader);

--- a/src/main/java/com/jarvis/cache/RefreshHandler.java
+++ b/src/main/java/com/jarvis/cache/RefreshHandler.java
@@ -154,10 +154,10 @@ public class RefreshHandler {
             try {
                 newCacheWrapper = dataLoader.init(pjp, cacheKey, cache, cacheHandler, arguments).loadData()
                         .getCacheWrapper();
-                isFirst = dataLoader.isFirst();
             } catch (Throwable ex) {
                 log.error(ex.getMessage(), ex);
             } finally {
+                isFirst = dataLoader.isFirst();
                 if(cacheHandler.getAutoLoadConfig().isDataLoaderPooled()) {
                     DataLoaderFactory factory = DataLoaderFactory.getInstance();
                     factory.returnObject(dataLoader);


### PR DESCRIPTION
数据加载失败，抛出异常时，isFirst值会恒为false，导致续租功能失效。现将isFirst赋值语句移到了finally中执行，保证了即使数据加载失败时续租功能依然正常。