### PR TITLE
fix: 使用FastjsonSerializer深拷贝时，List<Object>反序列化为List<JSONObject>的问题

### DIFF
--- a/src/main/java/com/jarvis/cache/serializer/FastjsonSerializer.java
+++ b/src/main/java/com/jarvis/cache/serializer/FastjsonSerializer.java
@@ -81,7 +81,8 @@ public class FastjsonSerializer implements ISerializer<Object> {
             cal.setTimeInMillis(((Calendar) obj).getTime().getTime());
             return cal;
         }
-        if (null != type) {
+        // List/Map在编译时类型会被擦除，导致List<Object>反序列化后变为List<JSONObject>
+        if (null != type && !(obj instanceof Collection) && !(obj instanceof Map)) {
             String json = JSON.toJSONString(obj, FEATURES);
             return JSON.parseObject(json, type);
         }

--- a/src/test/java/com/test/fastjson/DeepCloneTest.java
+++ b/src/test/java/com/test/fastjson/DeepCloneTest.java
@@ -70,7 +70,7 @@ public class DeepCloneTest {
             System.out.println("type2 is not ParameterizedType");
         }
         // test1();
-        // fastJsonTest();
+         fastJsonTest();
         deepClone(new JdkSerializer());
         deepClone(new HessianSerializer());
         deepClone(new FastjsonSerializer());
@@ -141,6 +141,19 @@ public class DeepCloneTest {
                 Object val=enty.getValue();
                 System.out.println(key.getClass().getName() + "--->" + key);
                 System.out.println(val.getClass().getName() + "--->" + val);
+            }
+        } catch(Exception e) {
+            // TODO Auto-generated catch block
+            e.printStackTrace();
+        }
+        System.out.println("--------------List------------------");
+        try {
+            List<User> userList = (List<User>) s.deepClone(list, List.class);
+            Iterator<User> it=userList.iterator();
+            System.out.println(userList.getClass().getName() + "--->" + userList);
+            while(it.hasNext()) {
+                User userObject=it.next();
+                System.out.println(userObject.getClass().getName() + "--->" + userObject);
             }
         } catch(Exception e) {
             // TODO Auto-generated catch block


### PR DESCRIPTION
使用LocalCache，配置copyValueOnGet和copyValueOnSet为true，使用FastjsonSerializer作为序列化工具，存储数据为Java对象的List或Map在编译时类型会被擦除，导致Object的List反序列化后变为JSONObject的List。增加的测试代码片段在修改之前运行时会报错，修改之后正常。